### PR TITLE
角色管理显示分组翻译，API管理显示原始分组字段

### DIFF
--- a/api/internal/i18n/locale/en.json
+++ b/api/internal/i18n/locale/en.json
@@ -18,6 +18,25 @@
 		"validationError": "Operation failed: Validation failed",
 		"notSingularError": "Operation failed: Data not unique"
 	},
+	"apiGroup":{
+		"member_rank": "Member Rank",
+		"member": "Member",
+		"tag": "Tag",
+		"file": "File",
+		"task_log": "Task Log",
+		"task": "Task",
+		"position": "Position",
+		"department": "Department",
+		"token": "Token",
+		"oauth": "Oauth",
+		"dictionary": "Dictionary",
+		"api": "API",
+		"authority": "Authority",
+		"captcha": "Captcha",
+		"menu": "Menu",
+		"role": "Role",
+		"user": "User"
+	},
 	"apiDesc": {
 		"createTag": "Create a tag",
 		"updateTag": "Update the tag",

--- a/api/internal/i18n/locale/zh.json
+++ b/api/internal/i18n/locale/zh.json
@@ -18,6 +18,25 @@
 		"validationError": "操作失败: 校验失败",
 		"notSingularError": "操作失败: 数据不唯一"
 	},
+	"apiGroup":{
+		"member_rank": "等级管理",
+		"member": "会员管理",
+		"tag": "标签管理",
+		"file": "文件管理",
+		"task_log": "任务日志",
+		"task": "任务管理",
+		"position": "职位管理",
+		"department": "部门管理",
+		"token": "令牌管理",
+		"oauth": "认证管理",
+		"dictionary": "字典管理",
+		"api": "接口管理",
+		"authority": "授权管理",
+		"captcha": "验证代码",
+		"menu": "菜单管理",
+		"role": "角色管理",
+		"user": "用户管理"
+	},
 	"apiDesc": {
 		"createTag": "创建文件标签",
 		"updateTag": "更新文件标签",

--- a/api/internal/logic/api/get_api_list_logic.go
+++ b/api/internal/logic/api/get_api_list_logic.go
@@ -43,7 +43,15 @@ func (l *GetApiListLogic) GetApiList(req *types.ApiListReq) (resp *types.ApiList
 	resp.Msg = l.svcCtx.Trans.Trans(l.ctx, i18n.Success)
 	resp.Data.Total = data.GetTotal()
 
+	// 接口分组翻译
+	var group = make(map[string]string)
 	for _, v := range data.Data {
+		// 检测是否存在分组翻译，避免多次获取
+		if _, exist := group[*v.ApiGroup]; !exist {
+			group[*v.ApiGroup] = l.svcCtx.Trans.Trans(l.ctx, "apiGroup."+*v.ApiGroup)
+		}
+		// 因为 ApiInfo 结构体的 Group 字段为指针 因此需要一个额外的临时变量
+		trans := group[*v.ApiGroup]
 		resp.Data.Data = append(resp.Data.Data,
 			types.ApiInfo{
 				BaseIDInfo: types.BaseIDInfo{
@@ -54,8 +62,9 @@ func (l *GetApiListLogic) GetApiList(req *types.ApiListReq) (resp *types.ApiList
 				Path:        v.Path,
 				Trans:       l.svcCtx.Trans.Trans(l.ctx, *v.Description),
 				Description: v.Description,
-				Group:       v.ApiGroup,
 				Method:      v.Method,
+				Group:       &trans, // 分组翻译
+				// Group:       v.ApiGroup,
 			})
 	}
 	return resp, nil

--- a/api/internal/types/types.go
+++ b/api/internal/types/types.go
@@ -649,12 +649,12 @@ type ApiAuthorityInfo struct {
 	// API path | API 路径
 	// required : true
 	// max length : 80
-	Path string `json:"path" validate="required,max=80"`
+	Path string `json:"path" validate:"required,max=80"`
 	// API method | API请求方法
 	// required : true
 	// min length : 3
 	// max length : 4
-	Method string `json:"method" validate="required,min=3,max=4"`
+	Method string `json:"method" validate:"required,min=3,max=4"`
 }
 
 // Create or update api authorization information request | 创建或更新API授权信息


### PR DESCRIPTION
当前项目在角色管理页面调用该接口时为了获取所有接口，每页大小被设置为10000，因此可以直接根据页大小来判断请求是否来自角色管理页面