### PR TITLE
fix:mobile phone number verification

### DIFF
--- a/api/desc/core/user.api
+++ b/api/desc/core/user.api
@@ -69,7 +69,7 @@ type (
         Nickname *string `json:"nickname,optional" validate:"omitempty,alphanumunicode,max=10"`
 
         // User's mobile phone number | 用户的手机号码
-        Mobile *string `json:"mobile,optional" validate:"omitempty,numeric,max=18"`
+        Mobile *string `json:"mobile,optional" validate:"omitempty,eq=|numeric,max=18"`
 
         // The user's email address | 用户的邮箱
         Email *string `json:"email,optional" validate:"omitempty,email,max=100"`
@@ -265,7 +265,7 @@ type (
         Avatar *string `json:"avatar" validate:"omitempty,max=300"`
 
         // User's mobile phone number | 用户的手机号码
-        Mobile *string `json:"mobile" validate:"omitempty,numeric,max=18"`
+        Mobile *string `json:"mobile" validate:"omitempty,eq=|numeric,max=18"`
 
         // The user's email address | 用户的邮箱
         Email *string `json:"email" validate:"omitempty,email,max=100"`

--- a/api/internal/types/types.go
+++ b/api/internal/types/types.go
@@ -231,7 +231,7 @@ type UserListReq struct {
 	Nickname *string `json:"nickname,optional" validate:"omitempty,alphanumunicode,max=10"`
 	// User's mobile phone number | 用户的手机号码
 	// max length : 18
-	Mobile *string `json:"mobile,optional" validate:"omitempty,numeric,max=18"`
+	Mobile *string `json:"mobile,optional" validate:"omitempty,eq=|numeric,max=18"`
 	// The user's email address | 用户的邮箱
 	// max length : 100
 	Email *string `json:"email,optional" validate:"omitempty,email,max=100"`
@@ -464,7 +464,7 @@ type ProfileInfo struct {
 	Avatar *string `json:"avatar" validate:"omitempty,max=300"`
 	// User's mobile phone number | 用户的手机号码
 	// max length : 18
-	Mobile *string `json:"mobile" validate:"omitempty,numeric,max=18"`
+	Mobile *string `json:"mobile" validate:"omitempty,eq=|numeric,max=18"`
 	// The user's email address | 用户的邮箱
 	// max length : 100
 	Email *string `json:"email" validate:"omitempty,email,max=100"`


### PR DESCRIPTION
go-playground/validator omitempty on pointers only checks if present or nil

Empty phone number submission is not allowed

References：https://github.com/go-playground/validator/issues/485

Note: There may be other fields that have the same problem