### PR TITLE
Security: Replace hardcoded JWT AccessSecret in example configs (CWE-798)

### DIFF
--- a/api/etc/core.yaml
+++ b/api/etc/core.yaml
@@ -4,7 +4,7 @@ Port: 9100
 Timeout: 6000
 
 Auth:
-  AccessSecret: jS6VKDtsJf3z1n2VKDtsJf3z1n2
+  AccessSecret: # CHANGE_ME: set your own JWT secret
   AccessExpire: 259200
 
 Log:

--- a/deploy/docker-compose/all_in_one/postgresql/api/etc/core.yaml
+++ b/deploy/docker-compose/all_in_one/postgresql/api/etc/core.yaml
@@ -4,7 +4,7 @@ Port: 9100
 Timeout: 6000
 
 Auth:
-  AccessSecret: jS6VKDtsJf3z1n2VKDtsJf3z1n2
+  AccessSecret: # CHANGE_ME: set your own JWT secret
   AccessExpire: 259200
 
 Log:

--- a/deploy/docker-compose/core-only/api/etc/core.yaml
+++ b/deploy/docker-compose/core-only/api/etc/core.yaml
@@ -4,7 +4,7 @@ Port: 9100
 Timeout: 6000
 
 Auth:
-  AccessSecret: jS6VKDtsJf3z1n2VKDtsJf3z1n2
+  AccessSecret: # CHANGE_ME: set your own JWT secret
   AccessExpire: 259200
 
 Log:


### PR DESCRIPTION
## Summary

Replace hardcoded JWT `AccessSecret` (`jS6VKDtsJf3z1n2VKDtsJf3z1n2`) in 3 example configuration files.

Anyone who knows this default secret can forge valid JWT tokens for any user and gain unauthorized access to any instance deployed with the default configuration.

## Changes
- `api/etc/core.yaml:7` — Replaced hardcoded secret
- `deploy/docker-compose/all_in_one/postgresql/api/etc/core.yaml:7` — Replaced hardcoded secret
- `deploy/docker-compose/core-only/api/etc/core.yaml:7` — Replaced hardcoded secret

## Test plan
- [ ] Users can set their own `AccessSecret` via environment variables or config override
- [ ] JWT authentication works with a properly configured secret
